### PR TITLE
Updates snippet and fixed double loading

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.
@@ -16,7 +17,10 @@ var RollbarIntegration = module.exports = integration('Rollbar')
   .option('identify', true)
   .option('accessToken', '')
   .option('environment', 'unknown')
-  .option('captureUncaught', true);
+  .option('captureUncaught', true)
+  .option('loadTimeout', 60000)
+  .option('verbose', false)
+  .option('rollbarJsUrl', null);
 
 /**
  * Initialize.
@@ -28,13 +32,20 @@ RollbarIntegration.prototype.initialize = function() {
   window._rollbarConfig = this.config = {
     accessToken: this.options.accessToken,
     captureUncaught: this.options.captureUncaught,
+    verbose: this.options.verbose,
     payload: {
       environment: this.options.environment
     }
   };
+
+  if (this.options.rollbarJsUrl) {
+    this.config.rollbarJsUrl = this.options.rollbarJsUrl;
+  }
+
   /* eslint-disable */
-  !function(r){function t(e){if(o[e])return o[e].exports;var n=o[e]={exports:{},id:e,loaded:!1};return r[e].call(n.exports,n,n.exports,t),n.loaded=!0,n.exports}var o={};return t.m=r,t.c=o,t.p="",t(0)}([function(r,t,o){"use strict";var e=o(1).Rollbar,n=o(2),a="https://d37gvrvc0wt4s1.cloudfront.net/js/v1.4/rollbar.min.js";_rollbarConfig.rollbarJsUrl=_rollbarConfig.rollbarJsUrl||a;var i=e.init(window,_rollbarConfig),l=n(i,_rollbarConfig);i.loadFull(window,document,!1,_rollbarConfig,l)},function(r,t){"use strict";function o(){var r=window.console;r&&"function"==typeof r.log&&r.log.apply(r,arguments)}function e(r){this.shimId=++u,this.notifier=null,this.parentShim=r,this.logger=o,this._rollbarOldOnError=null}function n(r,t,o){window._rollbarWrappedError&&(o[4]||(o[4]=window._rollbarWrappedError),o[5]||(o[5]=window._rollbarWrappedError._rollbarContext),window._rollbarWrappedError=null),r.uncaughtError.apply(r,o),t&&t.apply(window,o)}function a(r){var t=e;return l(function(){if(this.notifier)return this.notifier[r].apply(this.notifier,arguments);var o=this,e="scope"===r;e&&(o=new t(this));var n=Array.prototype.slice.call(arguments,0),a={shim:o,method:r,args:n,ts:new Date};return window._rollbarShimQueue.push(a),e?o:void 0})}function i(r,t){if(t.hasOwnProperty&&t.hasOwnProperty("addEventListener")){var o=t.addEventListener;t.addEventListener=function(t,e,n){o.call(this,t,r.wrap(e),n)};var e=t.removeEventListener;t.removeEventListener=function(r,t,o){e.call(this,r,t&&t._wrapped?t._wrapped:t,o)}}}function l(r,t){return t=t||o,function(){try{return r.apply(this,arguments)}catch(o){t("Rollbar internal error:",o)}}}var u=0;e.init=function(r,t){var o=t.globalAlias||"Rollbar";if("object"==typeof r[o])return r[o];r._rollbarShimQueue=[],r._rollbarWrappedError=null,t=t||{};var a=new e;return l(function(){if(a.configure(t),t.captureUncaught){a._rollbarOldOnError=r.onerror,r.onerror=function(){var r=Array.prototype.slice.call(arguments,0);n(a,a._rollbarOldOnError,r)};var e,l,u="EventTarget,Window,Node,ApplicationCache,AudioTrackList,ChannelMergerNode,CryptoOperation,EventSource,FileReader,HTMLUnknownElement,IDBDatabase,IDBRequest,IDBTransaction,KeyOperation,MediaController,MessagePort,ModalWindow,Notification,SVGElementInstance,Screen,TextTrack,TextTrackCue,TextTrackList,WebSocket,WebSocketWorker,Worker,XMLHttpRequest,XMLHttpRequestEventTarget,XMLHttpRequestUpload".split(",");for(e=0;e<u.length;++e)l=u[e],r[l]&&r[l].prototype&&i(a,r[l].prototype)}return r[o]=a,a},a.logger)()},e.prototype.loadFull=function(r,t,o,e,n){var a=function(){var t;if(void 0===r._rollbarPayloadQueue){var o,e,a,i;for(t=new Error("rollbar.js did not load");o=r._rollbarShimQueue.shift();)for(a=o.args,i=0;i<a.length;++i)if(e=a[i],"function"==typeof e){e(t);break}}"function"==typeof n&&n(t)},i=t.createElement("script"),u=t.getElementsByTagName("script")[0];i.src=e.rollbarJsUrl,i.async=!o,i.onload=l(a,this.logger),u.parentNode.insertBefore(i,u)},e.prototype.wrap=function(r,t){try{var o;if(o="function"==typeof t?t:function(){return t||{}},"function"!=typeof r)return r;if(r._isWrap)return r;if(!r._wrapped){r._wrapped=function(){try{return r.apply(this,arguments)}catch(t){throw t._rollbarContext=o()||{},t._rollbarContext._wrappedSource=r.toString(),window._rollbarWrappedError=t,t}},r._wrapped._isWrap=!0;for(var e in r)r.hasOwnProperty(e)&&(r._wrapped[e]=r[e])}return r._wrapped}catch(n){return r}};for(var s="log,debug,info,warn,warning,error,critical,global,configure,scope,uncaughtError".split(","),p=0;p<s.length;++p)e.prototype[s[p]]=a(s[p]);r.exports={Rollbar:e,_rollbarWindowOnError:n}},function(r,t){"use strict";r.exports=function(r,t){return function(o){if(!o&&!window._rollbarInitialized){var e=window.RollbarNotifier,n=t||{},a=n.globalAlias||"Rollbar",i=window.Rollbar.init(n,r);i._processShimQueue(window._rollbarShimQueue||[]),window[a]=i,window._rollbarInitialized=!0,e.processPayloads()}}}}]);
+  !function(r){function t(o){if(e[o])return e[o].exports;var n=e[o]={exports:{},id:o,loaded:!1};return r[o].call(n.exports,n,n.exports,t),n.loaded=!0,n.exports}var e={};return t.m=r,t.c=e,t.p="",t(0)}([function(r,t,e){"use strict";var o=e(1).Rollbar,n=e(2);_rollbarConfig.rollbarJsUrl=_rollbarConfig.rollbarJsUrl||"https://d37gvrvc0wt4s1.cloudfront.net/js/v1.7/rollbar.min.js";var a=o.init(window,_rollbarConfig),i=n(a,_rollbarConfig);a.loadFull(window,document,!_rollbarConfig.async,_rollbarConfig,i)},function(r,t){"use strict";function e(){var r=window.console;r&&"function"==typeof r.log&&r.log.apply(r,arguments)}function o(r,t){return t=t||e,function(){try{return r.apply(this,arguments)}catch(e){t("Rollbar internal error:",e)}}}function n(r,t,e){window._rollbarWrappedError&&(e[4]||(e[4]=window._rollbarWrappedError),e[5]||(e[5]=window._rollbarWrappedError._rollbarContext),window._rollbarWrappedError=null),r.uncaughtError.apply(r,e),t&&t.apply(window,e)}function a(r){this.shimId=++u,this.notifier=null,this.parentShim=r,this.logger=e,this._rollbarOldOnError=null}function i(r){var t=a;return o(function(){if(this.notifier)return this.notifier[r].apply(this.notifier,arguments);var e=this,o="scope"===r;o&&(e=new t(this));var n=Array.prototype.slice.call(arguments,0),a={shim:e,method:r,args:n,ts:new Date};return window._rollbarShimQueue.push(a),o?e:void 0})}function l(r,t){if(t.hasOwnProperty&&t.hasOwnProperty("addEventListener")){var e=t.addEventListener;t.addEventListener=function(t,o,n){e.call(this,t,r.wrap(o),n)};var o=t.removeEventListener;t.removeEventListener=function(r,t,e){o.call(this,r,t&&t._wrapped?t._wrapped:t,e)}}}var u=0;a.init=function(r,t){var e=t.globalAlias||"Rollbar";if("object"==typeof r[e])return r[e];r._rollbarShimQueue=[],r._rollbarWrappedError=null,t=t||{};var i=new a;return o(function(){if(i.configure(t),t.captureUncaught){i._rollbarOldOnError=r.onerror,r.onerror=function(){var r=Array.prototype.slice.call(arguments,0);n(i,i._rollbarOldOnError,r)};var o,a,u="EventTarget,Window,Node,ApplicationCache,AudioTrackList,ChannelMergerNode,CryptoOperation,EventSource,FileReader,HTMLUnknownElement,IDBDatabase,IDBRequest,IDBTransaction,KeyOperation,MediaController,MessagePort,ModalWindow,Notification,SVGElementInstance,Screen,TextTrack,TextTrackCue,TextTrackList,WebSocket,WebSocketWorker,Worker,XMLHttpRequest,XMLHttpRequestEventTarget,XMLHttpRequestUpload".split(",");for(o=0;o<u.length;++o)a=u[o],r[a]&&r[a].prototype&&l(i,r[a].prototype)}return r[e]=i,i},i.logger)()},a.prototype.loadFull=function(r,t,e,n,a){var i=function(){var t;if(void 0===r._rollbarPayloadQueue){var e,o,n,i;for(t=new Error("rollbar.js did not load");e=r._rollbarShimQueue.shift();)for(n=e.args,i=0;i<n.length;++i)if(o=n[i],"function"==typeof o){o(t);break}}"function"==typeof a&&a(t)},l=!1,u=t.createElement("script"),s=t.getElementsByTagName("script")[0],c=s.parentNode;u.src=n.rollbarJsUrl,u.async=!e,u.onload=u.onreadystatechange=o(function(){if(!(l||this.readyState&&"loaded"!==this.readyState&&"complete"!==this.readyState)){u.onload=u.onreadystatechange=null;try{c.removeChild(u)}catch(r){}l=!0,i()}},this.logger),c.insertBefore(u,s)},a.prototype.wrap=function(r,t){try{var e;if(e="function"==typeof t?t:function(){return t||{}},"function"!=typeof r)return r;if(r._isWrap)return r;if(!r._wrapped){r._wrapped=function(){try{return r.apply(this,arguments)}catch(t){throw t._rollbarContext=e()||{},t._rollbarContext._wrappedSource=r.toString(),window._rollbarWrappedError=t,t}},r._wrapped._isWrap=!0;for(var o in r)r.hasOwnProperty(o)&&(r._wrapped[o]=r[o])}return r._wrapped}catch(n){return r}};for(var s="log,debug,info,warn,warning,error,critical,global,configure,scope,uncaughtError".split(","),c=0;c<s.length;++c)a.prototype[s[c]]=i(s[c]);r.exports={Rollbar:a,_rollbarWindowOnError:n}},function(r,t){"use strict";r.exports=function(r,t){return function(e){if(!e&&!window._rollbarInitialized){var o=window.RollbarNotifier,n=t||{},a=n.globalAlias||"Rollbar",i=window.Rollbar.init(n,r);i._processShimQueue(window._rollbarShimQueue||[]),window[a]=i,window._rollbarInitialized=!0,o.processPayloads()}}}}]);
   /* eslint-enable */
+
   this.load(this.ready);
 };
 
@@ -57,7 +68,22 @@ RollbarIntegration.prototype.loaded = function() {
  */
 
 RollbarIntegration.prototype.load = function(callback) {
-  window.Rollbar.loadFull(window, document, true, this.config, callback);
+  var loadedCheck = this.loaded;
+  var startTime = (new Date()).getTime();
+  var timeout = this.options.loadTimeout;
+
+  function timer() {
+    if (loadedCheck()) {
+      return callback();
+    }
+    if ((new Date()).getTime() - startTime >= timeout) {
+      return callback(new Error('Rollbar timed out while loading'));
+    }
+
+    setTimeout(timer, 1);
+  }
+
+  timer();
 };
 
 /**

--- a/test/index.html
+++ b/test/index.html
@@ -2,12 +2,12 @@
 <html>
   <head>
     <title>integrations tests</title>
-    <link rel="stylesheet" href="/node_modules/mocha/mocha.css">
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css">
   </head>
   <body>
     <div id="mocha"></div>
-    <script src="/saucelabs.js"></script>
-    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="../saucelabs.js"></script>
+    <script src="../node_modules/mocha/mocha.js"></script>
     <script>
       mocha.setup({
         ui: 'bdd',
@@ -31,6 +31,6 @@
         }
       };
     </script>
-    <script src="/build.js"></script>
+    <script src="../build.js"></script>
   </body>
 </html>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var Analytics = require('analytics.js-core').constructor;
 var integration = require('analytics.js-integration');
@@ -5,12 +6,14 @@ var sandbox = require('clear-env');
 var tester = require('analytics.js-integration-tester');
 var Rollbar = require('../lib/');
 
+
 describe('Rollbar', function() {
   var analytics;
   var rollbar;
   var options = {
     accessToken: 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF',
-    environment: 'testenvironment'
+    environment: 'testenvironment',
+    verbose: true
   };
 
   beforeEach(function() {
@@ -44,13 +47,11 @@ describe('Rollbar', function() {
       it('should create the window.Rollbar object', function() {
         analytics.assert(!window.Rollbar);
         analytics.initialize();
-        analytics.page();
         analytics.assert(window.Rollbar);
       });
 
       it('should have all of the correct methods', function() {
         analytics.initialize();
-        analytics.page();
         analytics.assert(window.Rollbar);
         analytics.assert(window.Rollbar.debug);
         analytics.assert(window.Rollbar.info);
@@ -64,14 +65,12 @@ describe('Rollbar', function() {
       it('should set window.onerror', function() {
         var onerr = window.onerror;
         analytics.initialize();
-        analytics.page();
         analytics.assert(window.onerror !== onerr);
         analytics.assert(typeof window.onerror === 'function');
       });
 
       it('should call #load', function() {
         analytics.initialize();
-        analytics.page();
         analytics.called(rollbar.load);
       });
     });
@@ -84,52 +83,46 @@ describe('Rollbar', function() {
   });
 
   describe('after loading', function() {
-    beforeEach(function(done) {
-      analytics.once('ready', done);
-      analytics.initialize();
-      analytics.page();
-    });
-
     describe('#identify', function() {
-      beforeEach(function() {
-        analytics.stub(window, 'onerror');
-        analytics.stub(window.Rollbar, 'configure');
+      var rollbarClient;
+      beforeEach(function(done) {
+        analytics.initialize();
+        analytics.load(rollbar, function() {
+          rollbarClient = window.Rollbar;
+          analytics.stub(rollbarClient, 'configure');
+          done();
+        });
       });
 
       it('should send an id', function() {
         analytics.identify('id', {});
-        analytics.called(window.Rollbar.configure, {
+        analytics.called(rollbarClient.configure, {
           payload: { person: { id: 'id' } }
         });
       });
 
       it('should not send only traits', function() {
         analytics.identify({ trait: true });
-        analytics.didNotCall(window.Rollbar.configure);
+        analytics.didNotCall(rollbarClient.configure);
       });
 
       it('should send an id and traits', function() {
         analytics.identify('id', { trait: true });
-        analytics.called(window.Rollbar.configure, {
+        analytics.called(rollbarClient.configure, {
           payload: { person: { id: 'id', trait: true } }
         });
       });
     });
 
     describe('window.onerror', function() {
-      beforeEach(function() {
+      it('should call window.Rollbar.uncaughtError', function(done) {
+        window.onerror = undefined;
+        analytics.initialize();
         analytics.stub(window.Rollbar, 'uncaughtError');
-      });
 
-      it('should call window.Rollbar.uncaughtError', function() {
         var err = new Error('testing');
-        window.onerror(
-          'test message',
-          'http://foo.com',
-          33,
-          21,
-          err
-        );
+        window.onerror('test message', 'http://foo.com', 33, 21, err);
+
         analytics.called(window.Rollbar.uncaughtError,
           'test message',
           'http://foo.com',
@@ -137,6 +130,7 @@ describe('Rollbar', function() {
           21,
           err
         );
+        done();
       });
     });
   });


### PR DESCRIPTION
We are no longer calling loadFull() from the load() method since
initialize() will install the Rollbar shim. At this point, the integration
is ready to use. load() has been refactored to simply wait until the
full Rollbar notifier is downloaded and installed before calling
the callback.

@jondeandres @coryvirok 

Updated the Rollbar snippet to use the v1.4.4 code which fixes a bunch of issues, including browser tests.
